### PR TITLE
:open_file_folder: Fetch home directory 

### DIFF
--- a/linux_tvheadend_server_backup_and_restore
+++ b/linux_tvheadend_server_backup_and_restore
@@ -10,23 +10,29 @@
 
 sendbackupviaemail=""
 email=""
+service_name=tvheadend
+default_home_dir=/home/hts
 
 if [[ "$1" == "" ]];then echo "You need to run this script with parameter backup or restore (example: ./thisscriptname backup)" && exit;fi
 
+[ -r /etc/default/$service_name ] && . /etc/default/$service_name
+[ -z "$TVH_USER" ] || eval home_dir=~$TVH_USER
+[ -z "$home_dir" ] && home_dir=$default_home_dir
+
 if [[ "$1" == "backup" ]];then
 service tvheadend stop
-mv -f /home/hts/.hts/tvheadend_backup.tar /home/hts/.hts/tvheadend_backup_previous.tar 2>/dev/null
-tar -cpf /home/hts/.hts/tvheadend_backup.tar -C /home/hts/.hts/ tvheadend
+mv -f $home_dir/.hts/tvheadend_backup.tar $home_dir/.hts/tvheadend_backup_previous.tar 2>/dev/null
+tar -cpf $home_dir/.hts/tvheadend_backup.tar -C $home_dir/.hts/ tvheadend
 service tvheadend start
 if [[ "$sendbackupviaemail" == "yes" ]];then
 apt-get install mutt sendmail -y 2>/dev/null||yum install mutt sendmail -y 2>/dev/null
-echo "Made on $(hostname) on $(date --rfc-3339=date)"|mutt -s "TVHeadend server configuration backup" -a "/home/hts/.hts/tvheadend_backup.tar" -- "$email"
+echo "Made on $(hostname) on $(date --rfc-3339=date)"|mutt -s "TVHeadend server configuration backup" -a $home_dir"/.hts/tvheadend_backup.tar" -- "$email"
 fi
 fi
 
 if [[ "$1" == "restore" ]];then
 service tvheadend stop
-mv -f /home/hts/.hts/tvheadend /home/hts/.hts/tvheadend_before_last_restore 2>/dev/null
-tar -xpf /home/hts/.hts/tvheadend_backup.tar -C /home/hts/.hts/
+mv -f $home_dir/.hts/tvheadend $home_dir/.hts/tvheadend_before_last_restore 2>/dev/null
+tar -xpf $home_dir/.hts/tvheadend_backup.tar -C $home_dir/.hts/
 service tvheadend start
 fi


### PR DESCRIPTION
Fetch home directory in case user differs from hts or user hts has non-standard home directory. E.g. when using armbian (armbian-config) installation of tvheadend, tvheadend user is hts, but it's home directory is /var/lib/hts instead of /home/hts. In order to get home directory we need to get user name under which tvheadend service runs. This is retrieved from tvheadend service configuration file.

Works for my setup, however I did not test sending e-mails. 
My first ever contribution on github. :smile: 